### PR TITLE
Remove lifetime from `link` error return value

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -41,7 +41,7 @@ dependencies = [
 
 [[package]]
 name = "nom-rfc8288"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "itertools",
  "nom",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nom-rfc8288"
-version = "0.2.0"
+version = "0.2.1"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 description = "A nom based parser for RFC 8288"


### PR DESCRIPTION
The ergonomics of using `VerboseError<'a str>` were pretty terrible, so that's gone now and replaced with our own return value