### PR TITLE
Ensure that pipeline runs for external contributors

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -1,6 +1,6 @@
 name: Test Pipeline
 run-name: ${{ github.actor }} is running the test pipeline
-on: [push]
+on: [push, pull_request]
 jobs:
   cargo-test:
     runs-on: ubuntu-22.04


### PR DESCRIPTION
Currently it doesn't because of a missing trigger